### PR TITLE
COP-5597 Show user name in delete confirmation dialog

### DIFF
--- a/users-and-groups/src/components/shared/DeleteConfirmBox.tsx
+++ b/users-and-groups/src/components/shared/DeleteConfirmBox.tsx
@@ -46,6 +46,13 @@ const DeleteConfirmBox = ({
       if ('localizedName' in item) {
         return getContentLangValue(item.localizedName as Localized)
       }
+      if ('firstName' in item || 'lastName' in item) {
+        const firstName =
+          'firstName' in item ? String(item.firstName ?? '') : ''
+        const lastName = 'lastName' in item ? String(item.lastName ?? '') : ''
+        const fullName = `${firstName} ${lastName}`.trim()
+        if (fullName) return fullName
+      }
       if ('id' in item) return String(item.id)
     }
     return ''


### PR DESCRIPTION
## Summary
- Update `DeleteConfirmBox` to resolve display labels from `firstName` and `lastName` before falling back to entity `id`
- Ensures the user delete confirmation dialog shows the person's name (e.g. "John Smith") instead of their internal ID

## Test plan
- [ ] Open Users & Groups and click delete on a user row
- [ ] Verify the confirmation dialog shows the user's full name, not their ID
- [ ] Select a single user and use batch delete — confirm the dialog also shows the user's name
- [ ] Verify group delete confirmation still shows the group name as before


Made with [Cursor](https://cursor.com)